### PR TITLE
Fix researcher avatar height-width ratio in smaller screen

### DIFF
--- a/css/our-people.css
+++ b/css/our-people.css
@@ -19,7 +19,6 @@
   left:50%;
   transform: translate(-50%,-25%);
   /* border:1px solid black; */
-  height:100%;
   max-height: 100%;
 }
 .position {


### PR DESCRIPTION
**Before** - the aspect ratio of the avatar is incorrect in smaller screen

<img width="489" alt="Screenshot 2019-12-22 at 3 04 44 PM" src="https://user-images.githubusercontent.com/164703/71318556-469fe100-24cd-11ea-9e3f-cc9eb0707446.png">



**After** - do not set fixed height, so that height can grow/shrink with the width

<img width="486" alt="Screenshot 2019-12-22 at 3 04 52 PM" src="https://user-images.githubusercontent.com/164703/71318559-4a336800-24cd-11ea-8ea3-2024e9c576e6.png">
