### PR TITLE
Fix iframe overflow in our-contact.html

### DIFF
--- a/css/nav.css
+++ b/css/nav.css
@@ -11,7 +11,7 @@ li {
 
 nav{
     color:#00458A;
-    display:flex;
+    display:flex;    
     justify-content: space-between;    
     /* padding: 0px 90px 0px 90px; */
     box-shadow: 1px 1px 8px #888888;

--- a/css/our-contact.css
+++ b/css/our-contact.css
@@ -19,8 +19,8 @@
 
 .contact-container
 {
-    display: flex;
-    flex-flow: row-reverse;
+    display: flex;    
+    /* flex-flow: row-reverse; */
     align-items: center;
 }
 
@@ -42,7 +42,9 @@
 {
     .contact-container
     {
-        flex-flow: column-reverse;        
+        /* display: flex; */
+        display: initial;
+        /* flex-flow: column-reverse;         */
     }
 
     .contact-us

--- a/our-contact.html
+++ b/our-contact.html
@@ -53,7 +53,14 @@
     </nav>
   </div>
 
-  <div class="container contact-container my-5">
+  <div class="container contact-container my-5 ">    
+
+    <div class="contactUsMap mr-auto">
+      <iframe
+        src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d5982.739944897283!2d103.67717119554003!3d1.5323530415385636!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x31da73c109632e0b%3A0x74cda51bf210c304!2sSouthern%20University%20College!5e0!3m2!1sen!2smy!4v1576806157950!5m2!1sen!2smy"
+        class="map" allowfullscreen="" frameborder: 0;></iframe>
+    </div>
+
     <div class="d-flex flex-column contact-us">
       <h1 class="header">Contact Us</h1>
       <div>
@@ -65,12 +72,7 @@
         <span><a href="mailto:hmsim@sc.edu.my" target="_top" class="emailLink">hmsim@sc.edu.my</a></span>
       </div>
     </div>
-
-    <div class="contactUsMap mr-auto">
-      <iframe
-        src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d5982.739944897283!2d103.67717119554003!3d1.5323530415385636!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x31da73c109632e0b%3A0x74cda51bf210c304!2sSouthern%20University%20College!5e0!3m2!1sen!2smy!4v1576806157950!5m2!1sen!2smy"
-        class="map" allowfullscreen="" frameborder: 0;></iframe>
-    </div>
+    
   </div>
 
   <!-- footer -->


### PR DESCRIPTION
Before the fix, the iframe would overflow on IPhone devices.
However, the issue is solved after I removed the flex system when the screen is less than 768px from "contact-container" class in our-contact.css.